### PR TITLE
feat: Add /users OAuth access token method

### DIFF
--- a/lib/clerk/resources/users.rb
+++ b/lib/clerk/resources/users.rb
@@ -7,10 +7,15 @@ module Clerk
       extend Forwardable
 
       def initialize(client)
+        @client = client
         @resource = PluralResource.new(client, "users")
       end
 
       def_delegators :@resource, :all, :find, :update, :delete
+
+      def oauth_access_token(user_id, provider)
+        @client.request(:get, "#{@resource.resource_path(user_id)}/oauth_access_token/#{provider}")
+      end
     end
   end
 end

--- a/test/fixtures/users_oauth_access_token.json
+++ b/test/fixtures/users_oauth_access_token.json
@@ -1,0 +1,8 @@
+{
+  "token": "xxxx",
+  "provider": "oauth_hubspot",
+  "scopes": [
+    "oauth",
+    "contacts"
+  ]
+}

--- a/test/resources/users_test.rb
+++ b/test/resources/users_test.rb
@@ -12,6 +12,7 @@ class Clerk::Resources::UsersTest < Minitest::Test
         stub.patch("/users/user_1") { json_ok("user_1_updated") }
         stub.delete("/users/user_1") { json_ok("user_1_deleted") }
         stub.get("/users/unknown_id") { json_404 }
+        stub.get("/users/user_1/oauth_access_token/oauth_hubspot") { json_ok("users_oauth_access_token") }
       end
     end
 
@@ -51,5 +52,12 @@ class Clerk::Resources::UsersTest < Minitest::Test
     assert_raises Clerk::Errors::Fatal do
       mock_sdk.users.find("unknown_id")
     end
+  end
+
+  def test_oauth_access_token
+    response = mock_sdk.users.oauth_access_token("user_1", "oauth_hubspot")
+    assert_equal "xxxx", response["token"]
+    assert_equal "oauth_hubspot", response["provider"]
+    assert_equal ["oauth", "contacts"], response["scopes"]
   end
 end


### PR DESCRIPTION
See https://docs.clerk.dev/backend/backend-api-reference/beta-features#retrieve-an-oauth-access-token-for-a-user