### PR TITLE
fix: Skip interstitial on non-browser requests

### DIFF
--- a/lib/clerk/rack_middleware_v2.rb
+++ b/lib/clerk/rack_middleware_v2.rb
@@ -91,6 +91,15 @@ module Clerk
         return signed_out
       end
 
+      if development_or_staging? && !browser_request?(@req)
+        # the interstitial won't work if the user agent is not a browser, so
+        # short-circuit and avoid rendering it
+        #
+        # We only limit this to dev/stg because we're not yet sure how robust
+        # this strategy is, yet. In the future, we might enable it for prod too.
+        return signed_out
+      end
+
       ##########################################################################
       #                                                                        #
       #                             COOKIE AUTHENTICATION                      #
@@ -163,6 +172,12 @@ module Clerk
       request_host << ":#{req.port}" if req.port != 80 && req.port != 443
 
       origin != request_host
+    end
+
+    def browser_request?(req)
+      user_agent = req.env["HTTP_USER_AGENT"]
+
+      !user_agent.nil? && user_agent.starts_with?("Mozilla/")
     end
 
     def verify_token(token)


### PR DESCRIPTION
If the request looks like it came from a non-browser (e.g. curl), we
avoid rendering the interstitial since we know it can't work there - the
interstitial relies on the browser rendering the HTML response. In such
cases, the request is considered unauthenticated.

We only do this for development and staging instances for now. In the
future we might enable it for production too, if it proves a robust
mechanism.