### PR TITLE
Handle invalid json in authorization header

### DIFF
--- a/lib/clerk/rack_middleware_v2.rb
+++ b/lib/clerk/rack_middleware_v2.rb
@@ -80,7 +80,7 @@ module Clerk
         begin
           return signed_out(env) if !sdk.decode_token(header_token) # malformed JWT
         rescue JWT::DecodeError
-          return signed_out(env)  # malformed JSON authroization header
+          return signed_out(env)  # malformed JSON authorization header
         end
         
         token = verify_token(header_token)

--- a/lib/clerk/rack_middleware_v2.rb
+++ b/lib/clerk/rack_middleware_v2.rb
@@ -77,8 +77,12 @@ module Clerk
       #                                                                        #
       ##########################################################################
       if header_token
-        return signed_out(env) if !sdk.decode_token(header_token) # malformed JWT
-
+        begin
+          return signed_out(env) if !sdk.decode_token(header_token) # malformed JWT
+        rescue JWT::DecodeError
+          return signed_out(env)  # malformed JSON authroization header
+        end
+        
         token = verify_token(header_token)
         return signed_in(env, token, header_token) if token
 

--- a/lib/clerk/sdk.rb
+++ b/lib/clerk/sdk.rb
@@ -141,7 +141,10 @@ module Clerk
     # should not use this for untrusted messages! You most likely want to use
     # verify_token.
     def decode_token(token)
-      JWT.decode(token, nil, false).first
+      begin
+        JWT.decode(token, nil, false).first
+      rescue JWT::DecodeError
+      end
     end
 
     # Decode the JWT and verify it's valid (verify claims, signature etc.) using
@@ -168,7 +171,10 @@ module Clerk
         end
       end
 
-      JWT.decode(token, nil, true, algorithms: algorithms, jwks: jwk_loader).first
+      begin
+        JWT.decode(token, nil, true, algorithms: algorithms, jwks: jwk_loader).first
+      rescue JWT::DecodeError
+      end
     end
   end
 end

--- a/lib/clerk/sdk.rb
+++ b/lib/clerk/sdk.rb
@@ -168,10 +168,7 @@ module Clerk
         end
       end
 
-      begin
-        JWT.decode(token, nil, true, algorithms: algorithms, jwks: jwk_loader).first
-      rescue JWT::DecodeError
-      end
+      JWT.decode(token, nil, true, algorithms: algorithms, jwks: jwk_loader).first
     end
   end
 end

--- a/lib/clerk/sdk.rb
+++ b/lib/clerk/sdk.rb
@@ -141,10 +141,7 @@ module Clerk
     # should not use this for untrusted messages! You most likely want to use
     # verify_token.
     def decode_token(token)
-      begin
-        JWT.decode(token, nil, false).first
-      rescue JWT::DecodeError
-      end
+      JWT.decode(token, nil, false).first
     end
 
     # Decode the JWT and verify it's valid (verify claims, signature etc.) using


### PR DESCRIPTION
If an app uses HTTP basic auth anywhere in its application (e.g. using Sidekiq web interface with HTTP basic auth protection), the middleware errors out due to the HTTP_AUTHORIZATION header not being valid JSON. This prevents access to these routes, in my case preventing access to the Sidekiq Web UI which we use a great deal.

Added simple error handling, in this case, to prevent the middleware from blocking requests unnecessarily.