### PR TITLE
feat: Add support for excluding routes in middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ Clerk.configure do |c|
   c.base_url = "https://..." # if omitted: "https://api.clerk.dev/v1/"
   c.logger = Logger.new(STDOUT) # if omitted, no logging
   c.middleware_cache_store = ActiveSupport::Cache::FileStore.new("/tmp/clerk_middleware_cache") # if omitted: no caching
+  c.excluded_routes ["/foo", "/bar/*"]
 end
 ```
 

--- a/lib/clerk.rb
+++ b/lib/clerk.rb
@@ -18,9 +18,33 @@ module Clerk
     PRODUCTION_BASE_URL = "https://api.clerk.dev/v1/".freeze
     attr_accessor :api_key, :base_url, :logger, :middleware_cache_store
 
+    # An array of route paths on which the middleware will not execute.
+    #
+    # Only request paths that match _exactly_ one of the routes will be skipped.
+    # As a special case, if a route ends with '/*', then all request paths that
+    # match the route's prefix will be skipped.
+    #
+    # For example, given the following configuration:
+    #
+    #     excluded_routes = ["/foo", "/bar/*"]
+    #
+    # the following requests will be excluded:
+    #
+    # - /foo
+    # - /bar/baz
+    # - /bar/abc/xyz
+    #
+    # while the following requests will NOT be excluded:
+    #
+    # - /foo/bar
+    # - /bar
+    #
+    attr_accessor :excluded_routes
+
     def initialize
       @base_url = ENV.fetch("CLERK_API_BASE", PRODUCTION_BASE_URL)
       @api_key = ENV["CLERK_API_KEY"]
+      @excluded_routes = []
     end
   end
 end


### PR DESCRIPTION
This patch adds a new configuration option, with which one is able to declare routes that the middleware should not execute on.

This is done by either specifying an exact match, e.g. "/foo" or a prefix match, e.g. "/foo/*".

The latter syntax is implemented using a naive linear search, but since most people will use only a handful of those entries, this should be fine. (If we want to optimize this later on, we could use a prefix tree or something similar.)