### PR TITLE
fix: Make JWKS cache shared between SDK instances

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,14 +1,16 @@
 PATH
   remote: .
   specs:
-    clerk-sdk-ruby (2.7.0)
+    clerk-sdk-ruby (2.8.0)
+      concurrent-ruby (~> 1.1)
       faraday (~> 1.4.1)
-      jwt (~> 2.2)
+      jwt (~> 2.5)
 
 GEM
   remote: https://rubygems.org/
   specs:
     byebug (11.1.3)
+    concurrent-ruby (1.1.10)
     faraday (1.4.3)
       faraday-em_http (~> 1.0)
       faraday-em_synchrony (~> 1.0)
@@ -23,11 +25,11 @@ GEM
     faraday-net_http (1.0.1)
     faraday-net_http_persistent (1.2.0)
     jwt (2.5.0)
-    minitest (5.14.2)
+    minitest (5.16.3)
     multipart-post (2.2.3)
-    rake (13.0.3)
+    rake (13.0.6)
     ruby2_keywords (0.0.5)
-    timecop (0.9.4)
+    timecop (0.9.6)
 
 PLATFORMS
   universal-darwin-21

--- a/clerk-sdk-ruby.gemspec
+++ b/clerk-sdk-ruby.gemspec
@@ -28,7 +28,8 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "faraday", "~> 1.4.1"
-  spec.add_dependency "jwt", '~> 2.2'
+  spec.add_dependency "jwt", '~> 2.5'
+  spec.add_dependency "concurrent-ruby", "~> 1.1"
 
   spec.add_development_dependency "byebug", "~> 11.1"
   spec.add_development_dependency "timecop", "~> 0.9.4"

--- a/lib/clerk/jwks_cache.rb
+++ b/lib/clerk/jwks_cache.rb
@@ -1,0 +1,32 @@
+class JWKSCache
+  def initialize(lifetime)
+    @lifetime = lifetime
+    @jwks = nil
+    @last_update = nil
+    @lock = Concurrent::ReadWriteLock.new
+  end
+
+  def fetch(sdk, force_refresh: false, kid_not_found: false)
+    should_refresh = @lock.with_read_lock do
+      @jwks.nil? || @last_update.nil? || force_refresh ||
+        (Time.now.to_i-@last_update > @lifetime) ||
+        (kid_not_found && Time.now.to_i-@last_update > 300)
+    end
+
+    if should_refresh
+      @lock.with_write_lock do
+        @last_update = Time.now.to_i
+
+        @jwks = begin
+          sdk.jwks.all["keys"]
+        rescue Clerk::Errors::Base
+          nil
+        end
+      end
+    end
+
+    @lock.with_read_lock do
+      @jwks
+    end
+  end
+end


### PR DESCRIPTION
After 1123911 the JWKs cache wasn't working as expected, since the
middleware constructed a new SDK instance on each request. So each
request was effectively bypassing the cache, since the cache was
essentially an instance variable which was re-initialized anew every
time.

With this change, the JWKs cache is made thread-safe and shared between
all instances of the SDK.


Fixes AUTH-76