### PR TITLE
fix: Use JSON Content-Type in mutating requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@
 /tmp/
 
 .byebug_history
+.ruby-version
 *.gem
 
 .idea
+

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    clerk-sdk-ruby (2.8.0)
+    clerk-sdk-ruby (2.9.0.beta2)
       concurrent-ruby (~> 1.1)
       faraday (~> 1.4.1)
       jwt (~> 2.5)
@@ -24,8 +24,8 @@ GEM
     faraday-excon (1.1.0)
     faraday-net_http (1.0.1)
     faraday-net_http_persistent (1.2.0)
-    jwt (2.5.0)
-    minitest (5.16.3)
+    jwt (2.6.0)
+    minitest (5.17.0)
     multipart-post (2.2.3)
     rake (13.0.6)
     ruby2_keywords (0.0.5)

--- a/lib/clerk/resources/singular_resource.rb
+++ b/lib/clerk/resources/singular_resource.rb
@@ -7,7 +7,7 @@ module Clerk
       end
 
       def update(changes = {})
-        @client.request(:patch, @resource_path, body:changes)
+        @client.request(:patch, @resource_path, body: changes)
       end
     end
   end

--- a/lib/clerk/sdk.rb
+++ b/lib/clerk/sdk.rb
@@ -74,12 +74,14 @@ module Clerk
                    end
                  when :post
                    @conn.post(path, body) do |req|
-                     req.body = body
+                     req.body = body.to_json
+                     req.headers[:content_type] = "application/json"
                      req.options.timeout = timeout if timeout
                    end
                  when :patch
                    @conn.patch(path, body) do |req|
-                     req.body = body
+                     req.body = body.to_json
+                     req.headers[:content_type] = "application/json"
                      req.options.timeout = timeout if timeout
                    end
                  when :delete


### PR DESCRIPTION
The Backend API supports both form-urlencoded and application/json content types in requests. However, we're slowly fading out support for form-urlencoded and transitioning to application/json.

Most important, the Ruby SDK generated payloads that the Backend API couldn't properly unmarshal, particularly in the case of payloads like the following:

    { backup_codes: ["abcdef", "zxcqwe"] }

in such cases, the resulting payload would be:

    backup_codes[]: "abcdef; zxcqwe"

which the Backend API didn't know how to properly parse.

Fixes AUTH-129