### PR TITLE
chore: Migrate README urls to clerk.com

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,7 +54,7 @@ Identical to 2.9.0.beta3
 
 ## 2.2.0 - 2022-08-26
 
-- feat: Add support for the [users.create](https://reference.clerk.dev/reference/backend-api-reference/users#create-a-user) endpoint
+- feat: Add support for the [users.create](https://clerk.com/docs/reference/backend-api/tag/Users#operation/CreateUser) endpoint
 
 ## 2.1.2 - 2022-08-26
 
@@ -67,15 +67,15 @@ Identical to 2.9.0.beta3
 ## 2.0.0 - 2021-10-21
 
 This release introduces the new networkless middleware which works with the new 
-authentication scheme, [Auth v2](https://docs.clerk.dev/main-concepts/auth-v2).
+authentication scheme, [Auth v2](https://clerk.com/docs/upgrade-guides/auth-v2).
 
 It is backwards-incompatible with applications using Auth v1.
 
 - [BREAKING]: In order to use this version, you must set the authVersion prop 
     accordingly in your frontend: `Clerk.load({authVersion: 2})`
 
-For more information on Auth v2, please refer to 
-https://docs.clerk.dev/main-concepts/auth-v2.
+For more information on Auth v2, please refer to
+https://clerk.com/docs/upgrade-guides/auth-v2.
 
 ## 1.0.3 - 2021-07-21
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <a href="https://www.clerk.dev/?utm_source=github&utm_medium=starter_repos&utm_campaign=sdk_ruby" target="_blank" align="center">
+  <a href="https://www.clerk.com/?utm_source=github&utm_medium=starter_repos&utm_campaign=sdk_ruby" target="_blank" align="center">
     <picture>
       <source media="(prefers-color-scheme: dark)" srcset="./docs/clerk-logo-dark.png">
       <img src="./docs/clerk-logo-light.png" height="64">
@@ -10,10 +10,10 @@
 
 # Clerk Ruby SDK
 
-This SDK allows you to call the [Clerk](https://www.clerk.dev/?utm_source=github&utm_medium=starter_repos&utm_campaign=sdk_ruby) Backend API from Ruby code without having to implement the calls yourself.
+This SDK allows you to call the [Clerk](https://www.clerk.com/?utm_source=github&utm_medium=starter_repos&utm_campaign=sdk_ruby) Backend API from Ruby code without having to implement the calls yourself.
 
 [![chat on Discord](https://img.shields.io/discord/856971667393609759.svg?logo=discord)](https://discord.com/invite/b5rXHjAg7A)
-[![documentation](https://img.shields.io/badge/documentation-clerk-green.svg)](https://docs.clerk.dev)
+[![documentation](https://img.shields.io/badge/documentation-clerk-green.svg)](https://clerk.com/docs)
 [![twitter](https://img.shields.io/twitter/follow/ClerkDev?style=social)](https://twitter.com/intent/follow?screen_name=ClerkDev)
 
 ---
@@ -25,7 +25,7 @@ Would you like to work on Open Source software and help maintain this repository
 ---
 
 **Note**: You're looking at the main branch, which requires that you use [Auth
-v2](https://clerk.dev/docs/upgrade-guides/auth-v2).
+v2](https://clerk.com/docs/upgrade-guides/auth-v2).
 
 If you're looking for the legacy authentication scheme, refer to the
 [`v1`](https://github.com/clerkinc/clerk-sdk-ruby/tree/v1) branch.
@@ -49,10 +49,10 @@ Or install it yourself as:
 ## Quick Start
 
 First, you need to get an API key for a Clerk instance. This is done via the
-[Clerk dashboard](https://dashboard.clerk.dev/applications).
+[Clerk dashboard](https://dashboard.clerk.com/applications).
 
 Then you can instantiate a `Clerk::SDK` instance and access all
-[Backend API](https://docs.clerk.dev/backend/backend-api-reference) endpoints.
+[Backend API](https://clerk.com/docs/reference/backend-api) endpoints.
 Here's a quick example:
 
 ```ruby
@@ -156,7 +156,7 @@ API then responds with JSON which is then converted and returned as a Ruby
 `Hash`, or `Array` of hashes. Errors are also returned as a JSON object, with a
 single key (`errors`) containing an array of error objects.
 
-Read the [API documentation](https://docs.clerk.dev/backend/backend-api-reference)
+Read the [API documentation](https://clerk.com/docs/reference/backend-api)
 for details on expected parameters and response formats.
 
 ## Development

--- a/lib/clerk/authenticatable.rb
+++ b/lib/clerk/authenticatable.rb
@@ -24,7 +24,7 @@ module Clerk
     # which already contains the verified claims as retrieved from the session
     # token.
     #
-    # See https://docs.clerk.dev/reference/backend-api-reference/sessions#verify-a-session
+    # See https://clerk.com/docs/reference/backend-api/tag/Sessions#operation/VerifySession
     def clerk_reverify_session!
       request.env["clerk"].verify_session
     end


### PR DESCRIPTION
Replace all occurrences of `clerk.dev` with `clerk.com` in the repo docs