### PR TITLE
Allow the use of Faraday 2.x

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     clerk-sdk-ruby (2.10.0)
       concurrent-ruby (~> 1.1)
-      faraday (~> 1.4.1)
+      faraday (> 1.4.1, < 3.0)
       jwt (~> 2.5)
 
 GEM
@@ -32,6 +32,7 @@ GEM
     timecop (0.9.6)
 
 PLATFORMS
+  aarch64-linux
   arm64-darwin-22
   universal-darwin-21
   x86_64-linux

--- a/clerk-sdk-ruby.gemspec
+++ b/clerk-sdk-ruby.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "faraday", "~> 1.4.1"
+  spec.add_dependency "faraday", "> 1.4.1", '< 3.0'
   spec.add_dependency "jwt", '~> 2.5'
   spec.add_dependency "concurrent-ruby", "~> 1.1"
 

--- a/lib/clerk/rack_middleware_v2.rb
+++ b/lib/clerk/rack_middleware_v2.rb
@@ -203,7 +203,8 @@ module Clerk
     end
 
     def development_or_staging?
-      Clerk.configuration.api_key.start_with?("test_") ||
+      Clerk.configuration.api_key.nil? ||
+        Clerk.configuration.api_key.start_with?("test_") ||
         Clerk.configuration.api_key.start_with?("sk_test_")
     end
 


### PR DESCRIPTION
We have a project that already contains Faraday 2.x.

This allows the use of Faraday 2.x and adds a fix for initializing the SDK when the config is not set.

Faraday 2 accepts a lambda function for Auth, which actually allows setting the API Key after initialization. Without the lambda function and in Faraday 1.x there's actually an issue where the new API key wouldn't be picked up anyway if the SDK is already initialized earlier without it.