### PR TITLE
Skip middleware if there is no API key set

### DIFF
--- a/lib/clerk/rack_middleware_v2.rb
+++ b/lib/clerk/rack_middleware_v2.rb
@@ -95,8 +95,9 @@ module Clerk
     end
 
     def call(env)
-      env = env
       req = Rack::Request.new(env)
+
+      return @app.call(env) if Clerk.configuration.api_key.nil?
 
       if @excluded_routes[req.path]
         return @app.call(env)


### PR DESCRIPTION
This calls the next item in the middleware stack and passes on if there is now API key set.

In our case this was mainly just about testing, in some cases I don't want calls from the middleware getting in the way whilst testing, rather than unload the middleware after it has been setup it's easier to just pass it unless there's an API key present.

this also removes env=env which doesn't do anything.