### PR TITLE
fix: Properly set API key in Faraday 2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    clerk-sdk-ruby (2.10.0)
+    clerk-sdk-ruby (2.11.0)
       concurrent-ruby (~> 1.1)
       faraday (>= 1.4.1, < 3.0)
       jwt (~> 2.5)
@@ -19,7 +19,7 @@ GEM
     faraday-net_http (3.0.2)
     jwt (2.7.1)
     minitest (5.20.0)
-    rake (13.0.6)
+    rake (13.1.0)
     ruby2_keywords (0.0.5)
     timecop (0.9.8)
 

--- a/lib/clerk/rack_middleware_v2.rb
+++ b/lib/clerk/rack_middleware_v2.rb
@@ -203,12 +203,15 @@ module Clerk
     end
 
     def development_or_staging?
-      Clerk.configuration.api_key.start_with?("test_") ||
-        Clerk.configuration.api_key.start_with?("sk_test_")
+      Clerk.configuration.api_key &&
+      (Clerk.configuration.api_key.start_with?("test_") ||
+        Clerk.configuration.api_key.start_with?("sk_test_"))
     end
 
     def production?
-      !development_or_staging?
+      Clerk.configuration.api_key &&
+      (Clerk.configuration.api_key.start_with?("live_") ||
+        Clerk.configuration.api_key.start_with?("sk_live_"))
     end
 
     def cross_origin_request?(req)

--- a/lib/clerk/sdk.rb
+++ b/lib/clerk/sdk.rb
@@ -52,10 +52,10 @@ module Clerk
                      URI(base_url)
                    end
 
-        api_key ||= if Faraday::VERSION.to_i < 2
-            Clerk.configuration.api_key
-        elsif Clerk.configuration.api_key.nil?
-          -> { raise ArgumentError, "Clerk secret key is not set" }
+        api_key ||= Clerk.configuration.api_key
+
+        if Faraday::VERSION.to_i >= 2 && api_key.nil?
+          api_key = -> { raise ArgumentError, "Clerk secret key is not set" }
         end
 
         logger = logger || Clerk.configuration.logger


### PR DESCRIPTION
This fixes a regression introduced with #37, which caused the Clerk API key to not be properly set when requesting Clerk's Backend API, when Faraday v2 was used.

Fixes https://github.com/clerkinc/clerk-sdk-ruby/pull/37#issuecomment-1786060568